### PR TITLE
fix(readme): rework agency listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,14 +96,12 @@ List of notable tech companies in Singapore. Useful when looking for a new job.
 ## Government
 
 ### Civil
-
+- OGP ⏸️
 - GovTech
-  - OGP ⏸️
   - ESTL 🟢
   - DSAID (Data Science and AI Division) 🟢
 - HDB 🟢
 - NLB 🟢
-- IRAS 🟢
 - STB 🟢
 - MAS 🟢
 


### PR DESCRIPTION
- OGP moved to alongside GovTech, to reflect the former's autonomy from the latter
- IRAS removed after checking LinkedIn job listings