### PR TITLE
Add VMware and VMware Tanzu Labs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ List of notable tech companies in Singapore. Useful when looking for a new job.
 - Stripe 🟠 [Layoff 14% in Nov 2022](https://www.cnbc.com/2022/11/03/stripe-plans-to-lay-off-14percent-of-workers.html)
 - Twitter 🟠 [Layoff 80% in Nov 2022](https://www.reuters.com/legal/twitter-again-accused-legal-violations-during-mass-layoffs-2023-04-04/)
 - Cloudflare 🔴 [Anecdotes in Jan 2024](https://news.ycombinator.com/item?id=38961859)
-- VMware 🔴 [Mass layoffs Nov 2023 - August 2024](https://techwireasia.com/12/2023/what-happens-next-with-vmware-after-layoffs-and-redundancy/)
 
 ## Chinese FAANG
 
@@ -159,6 +158,7 @@ List of notable tech companies in Singapore. Useful when looking for a new job.
 - Coupang
 - TheTradeDesk
 - ExpressVPN 🔴 [Layoff 200 in July 2023](https://sg.news.yahoo.com/tech-layoffs-cybersecurity-firm-behind-160913325.html)
+- VMware 🔴 [Mass layoffs Nov 2023 - August 2024](https://techwireasia.com/12/2023/what-happens-next-with-vmware-after-layoffs-and-redundancy/)
 - Zoom 🔴
 
 ---


### PR DESCRIPTION
VMware was acquired by Broadcom in Nov 2023 with most people in Southeast Asia made redundant. A small team of salespeople and consultants remains until August 2024, possibly earlier.